### PR TITLE
Fix #7 : added prettier

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "semi": true,
+  "trailingComma": "all"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7938,6 +7938,12 @@
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
     },
+    "prettier": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.11.1.tgz",
+      "integrity": "sha512-T/KD65Ot0PB97xTrG8afQ46x3oiVhnfGjGESSI9NWYcG92+OUPZKkwHqGWXH2t9jK1crnQjubECW0FuOth+hxw==",
+      "dev": true
+    },
     "pretty-bytes": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-4.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,12 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
+    "lint":
+      "prettier --config ./.prettierrc 'src/**/*.js' 'src/**/*.css' --write",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"
+  },
+  "devDependencies": {
+    "prettier": "^1.11.1"
   }
 }


### PR DESCRIPTION
## Issue
https://github.com/rwieruch/react-graphql-github-apollo/issues/7
## Completed
 - [X] add a Prettier configuration file to the project (e.g. with dangling comma true, semicolons true)

 - [X] add a "prettier" script to the scripts package.json block to format all files via the command line. This can be done one time initially to have a unified code style.

- [ ] add a Contribution section at the bottom of the README.md mentioning to install a Prettier editor/IDE integration (e.g. VS Code) and to enforce it on save file (e.g. VS Code).