### PR TITLE
Pagination with Lenses: Replacing the verbose deep object spreading

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9173,6 +9173,11 @@
         "performance-now": "2.1.0"
       }
     },
+    "ramda": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.25.0.tgz",
+      "integrity": "sha512-GXpfrYVPwx3K7RQ6aYT8KPS8XViSXUVJT1ONhoKPE9VAleW42YE+U+8VEyGWt41EnEQW7gwecYJriTI0pKoecQ=="
+    },
     "randomatic": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "apollo-link-http": "^1.5.3",
     "graphql": "^0.13.2",
     "graphql-tag": "^2.8.0",
+    "ramda": "^0.25.0",
     "react": "^16.2.0",
     "react-apollo": "^2.1.0",
     "react-dom": "^16.2.0",

--- a/src/Repository/RepositoryList/index.js
+++ b/src/Repository/RepositoryList/index.js
@@ -1,4 +1,5 @@
 import React, { Fragment } from 'react';
+import { lensPath, set, view, compose } from 'ramda';
 
 import RepositoryItem from '../RepositoryItem';
 
@@ -17,20 +18,18 @@ const doFetchMore = fetchMore => (cursor, { entry }) =>
         return previousResult;
       }
 
-      return {
-        ...previousResult,
-        [entry]: {
-          ...previousResult[entry],
-          repositories: {
-            ...previousResult[entry].repositories,
-            ...fetchMoreResult[entry].repositories,
-            edges: [
-              ...previousResult[entry].repositories.edges,
-              ...fetchMoreResult[entry].repositories.edges,
-            ],
-          },
-        },
-      };
+      const repositoriesLens = lensPath([entry, 'repositories']);
+      const edgesLens = lensPath([entry, 'repositories', 'edges']);
+
+      const updatedRepositoryEdges = [
+        ...view(edgesLens, previousResult),
+        ...view(edgesLens, fetchMoreResult),
+      ];
+
+      return compose(
+        set(edgesLens, updatedRepositoryEdges),
+        set(repositoriesLens, view(repositoriesLens, fetchMoreResult)),
+      )(previousResult);
     },
   });
 


### PR DESCRIPTION
Since there is no best practice yet how to update paginated data in Apollo client (Is there? [0][1] If there is one, please tell me! :)), I replaced the deeply nested object spreading with [Ramda's lenses](http://ramdajs.com/docs/#lens). It makes the updating of the deeply nested immutable data structure concise again. 

[0] As I read somewhere else, Apollo comes with its own kind of ImmutableJS library? I would love to avoid using yet another immutable library in the future. That's why I didn't use it in this project in the first place.

[1] As I know, the `updateQuery` property will go away eventually. (Am I correct?) I would hope that there is some way to use the Apollo client/cache directly in the pagination update mechanism.
 Then it would be possible to use readQuery/writeQuery or even readFragment/writeFragment (for deeply nested structures) on the client instead. It should be similar to the `update` option in my opinion. Not sure about the plans of the Apollo team, but maybe it becomes merged with the `update` option eventually.

I would be curious what you all think about this PR :)
cc @peggyrayzis